### PR TITLE
Added missing } to the highscore definition.

### DIFF
--- a/assets/js/logic.js
+++ b/assets/js/logic.js
@@ -79,6 +79,7 @@ function highscoresUpload() {
     highscores = JSON.parse(localStorage.getItem("highscores"));
   } else {
     highscores = [];
+  }
 }
 // ## Function to get the current question text, based on the quiz stage:
 function questionsGetText() {


### PR DESCRIPTION
Added missing } to the highscore definition, as the page was displaying an error.